### PR TITLE
[Feature] Rename @ExcelModel.explicit

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -647,8 +647,8 @@ You can also refer the other fields. We call this as `variable`.
 <br>
 
 Field you can refer is only targeted field.
-
-It means you cannot refer the field that is annotated with `@ExcelColumn(ignored = true)` (or `ExcelModel#explicit()`).
+It means you cannot refer the field that is annotated with `@ExcelColumn(ignored = true)`
+or the field is not annotated with `@ExcelColumn` when its model is annotated with `@ExcelModel(onlyExplicitlyAnnotated = true)`.
 
 If type of expression result is not `String`, the converter will invoke `Object#toString()`.
 

--- a/core/README.md
+++ b/core/README.md
@@ -157,7 +157,7 @@ Model must has a constructor without parameters, so that `ExcelReader` can insta
 ## Exclude field
 
 ```java
-@ExcelIgnore
+@ExcelColumn(ignored = true)
 private String accessId;
 ```
 
@@ -167,7 +167,7 @@ private String accessId;
 | ------------ | ------------ | ----- | ----- | ------ | ------ |
 | 10000        | Choco cereal |       | 0.0   | 20.5   | 580.5  |
 
-If you want to exclude several fields, annotate `@ExcelIgnore` to them.
+If you want to exclude several fields, annotate `@ExcelColumn(ignored = true)` to them.
 
 <br>
 
@@ -187,11 +187,10 @@ If you want to exclude several fields, annotate `@ExcelIgnore` to them.
 ]
 ```
 
-`ExcelReader` will pass the fields that annotated `@ExcelIgnore` by.
+`ExcelReader` will pass the fields annotated with `@ExcelColumn(ignored = true)`.
 
-If column `accessId` exists in Excel sheet and `Product#accessId` is still annotated `@ExcelIgnore`,
-
-the exception will occur because of setting `accessId` to `width` (NumberFormatException).
+If column `accessId` exists in Excel sheet and `Product#accessId` is still annotated `@ExcelColumn(ignored = true)`,
+exception will occur because of setting `accessId` to `width` (NumberFormatException).
 
 <br><br>
 
@@ -304,10 +303,10 @@ If the field that is annotated by `@ExcelReadExpression`, its default value does
 class NoFieldModel {}
 
 class AllIgnoredModel {
-    @ExcelIgnore
+    @ExcelColumn(ignored = true)
     private int number;
     
-    @ExcelIgnore
+    @ExcelColumn(ignored = true)
     private Character character;
 }
 ```
@@ -649,7 +648,7 @@ You can also refer the other fields. We call this as `variable`.
 
 Field you can refer is only targeted field.
 
-It means you cannot refer the field that is annotated with `@ExcelIgnore` (or `ExcelModel#explicit()`).
+It means you cannot refer the field that is annotated with `@ExcelColumn(ignored = true)` (or `ExcelModel#explicit()`).
 
 If type of expression result is not `String`, the converter will invoke `Object#toString()`.
 

--- a/core/src/main/java/com/github/javaxcel/core/annotation/ExcelModel.java
+++ b/core/src/main/java/com/github/javaxcel/core/annotation/ExcelModel.java
@@ -28,7 +28,7 @@ import com.github.javaxcel.styler.ExcelStyleConfig;
 import com.github.javaxcel.styler.NoStyleConfig;
 
 /**
- *
+ * Excel model.
  */
 @Documented
 @Target(ElementType.TYPE)
@@ -53,7 +53,7 @@ public @interface ExcelModel {
      *
      * @return policy that determines whether this will select explicitly designated fields or not.
      */
-    boolean explicit() default false;
+    boolean onlyExplicitlyAnnotated() default false;
 
     /**
      * Policy that determines whether this will set constraint to {@link Enum} field or not.

--- a/core/src/main/java/com/github/javaxcel/core/util/FieldUtils.java
+++ b/core/src/main/java/com/github/javaxcel/core/util/FieldUtils.java
@@ -56,13 +56,13 @@ public final class FieldUtils {
      *
      * <p> This doesn't return the fields on {@link ExcelColumn} whose {@link ExcelColumn#ignored()} is {@code true}.
      *
-     * <p> If the model class' {@link ExcelModel#explicit()} is {@code true},
+     * <p> If {@link ExcelModel#onlyExplicitlyAnnotated()} on the model class is {@code true},
      * this excludes the fields not annotated with {@link ExcelColumn}.
      *
      * @param type type of the object
      * @return targeted fields
      * @see ExcelModel#includeSuper()
-     * @see ExcelModel#explicit()
+     * @see ExcelModel#onlyExplicitlyAnnotated()
      */
     public static List<Field> getTargetedFields(Class<?> type) {
         // Gets the fields depending on the policies.
@@ -79,8 +79,8 @@ public final class FieldUtils {
         filter = filter.and(it -> !Optional.ofNullable(it.getAnnotation(ExcelColumn.class))
                 .map(ExcelColumn::ignored)
                 .orElse(false));
-        // Excludes the implicit fields.
-        if (excelModel != null && excelModel.explicit()) {
+        // Excludes the fields which is not annotated with @ExcelColumn.
+        if (excelModel != null && excelModel.onlyExplicitlyAnnotated()) {
             filter = filter.and(it -> it.isAnnotationPresent(ExcelColumn.class));
         }
 

--- a/core/src/test/groovy/com/github/javaxcel/core/in/resolver/impl/constructor/success/DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec.groovy
+++ b/core/src/test/groovy/com/github/javaxcel/core/in/resolver/impl/constructor/success/DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec.groovy
@@ -59,7 +59,7 @@ class DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec extends Specif
     }
 
     @SuppressWarnings("unused")
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class ExplicitField {
         @ExcelColumn
         final List<Integer> integers

--- a/core/src/test/groovy/com/github/javaxcel/core/in/resolver/impl/method/success/DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec.groovy
+++ b/core/src/test/groovy/com/github/javaxcel/core/in/resolver/impl/method/success/DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec.groovy
@@ -65,7 +65,7 @@ class DuplicatedParamTypeAndUnmatchedParamNameButIgnoredFieldSpec extends Specif
     }
 
     @SuppressWarnings("unused")
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class ExplicitField {
         @ExcelColumn
         final List<Integer> integers

--- a/core/src/test/groovy/com/github/javaxcel/core/util/FieldUtilsSpec.groovy
+++ b/core/src/test/groovy/com/github/javaxcel/core/util/FieldUtilsSpec.groovy
@@ -156,14 +156,14 @@ class FieldUtilsSpec extends Specification {
         String f1
     }
 
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class Explicit {
         @ExcelColumn
         Double f0
         String f1
     }
 
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class Parent {
         @ExcelColumn
         Double f0
@@ -178,7 +178,7 @@ class FieldUtilsSpec extends Specification {
         String f1
     }
 
-    @ExcelModel(explicit = true, includeSuper = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true, includeSuper = true)
     private static class ExplicitAndIncludedSuper extends Parent {
         String f1
     }

--- a/core/src/test/java/com/github/javaxcel/core/core/modelwriter/IgnoreTest.java
+++ b/core/src/test/java/com/github/javaxcel/core/core/modelwriter/IgnoreTest.java
@@ -42,7 +42,7 @@ import static com.github.javaxcel.core.TestUtils.*;
 
 /**
  * @see ExcelColumn#ignored()
- * @see ExcelModel#explicit()
+ * @see ExcelModel#onlyExplicitlyAnnotated()
  * @see ExcelUtils#autoResizeColumns(Sheet, int)
  */
 @StopwatchProvider
@@ -102,7 +102,7 @@ class IgnoreTest extends ModelWriterTester {
         private Double weight;
     }
 
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class ExplicitModel {
         @ExcelColumn
         private Long id;

--- a/core/src/test/java/com/github/javaxcel/core/core/modelwriter/NoTargetedFieldTest.java
+++ b/core/src/test/java/com/github/javaxcel/core/core/modelwriter/NoTargetedFieldTest.java
@@ -66,7 +66,7 @@ class NoTargetedFieldTest {
         private Character character;
     }
 
-    @ExcelModel(explicit = true)
+    @ExcelModel(onlyExplicitlyAnnotated = true)
     private static class ExplicitModel {
         private Long id;
         private String name;

--- a/core/src/test/java/com/github/javaxcel/core/model/computer/Computer.java
+++ b/core/src/test/java/com/github/javaxcel/core/model/computer/Computer.java
@@ -18,7 +18,11 @@ import com.github.javaxcel.core.internal.style.DefaultHeaderStyleConfig;
 @Setter
 @ToString
 @EqualsAndHashCode(of = {"cpu", "disk", "manufacturer", "price"})
-@ExcelModel(explicit = true, headerStyle = DefaultHeaderStyleConfig.class, bodyStyle = DefaultBodyStyleConfig.class)
+@ExcelModel(
+        onlyExplicitlyAnnotated = true,
+        headerStyle = DefaultHeaderStyleConfig.class,
+        bodyStyle = DefaultBodyStyleConfig.class
+)
 public class Computer {
 
     @ExcludeOnPercentage(0.1)


### PR DESCRIPTION
Rename `@ExcelModel.explicit` to `@ExcelModel.onltExplicitlyAnnotated`.